### PR TITLE
fix: build failed when react imported as default

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { BaseSchemes, CanAssignSignal, Scope } from 'rete'
 
 import { RenderPreset } from './presets/types'

--- a/src/presets/classic/components/Connection.tsx
+++ b/src/presets/classic/components/Connection.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import { ClassicScheme } from '../types'

--- a/src/presets/classic/components/ConnectionWrapper.tsx
+++ b/src/presets/classic/components/ConnectionWrapper.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { createContext, useContext, useEffect, useState } from 'react'
 
 import { Position } from '../../../types'

--- a/src/presets/classic/components/Control.tsx
+++ b/src/presets/classic/components/Control.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { ClassicPreset } from 'rete'
 import styled from 'styled-components'
 

--- a/src/presets/classic/components/Node.tsx
+++ b/src/presets/classic/components/Node.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import styled, { css } from 'styled-components'
 
 import { ClassicScheme, RenderEmit } from '../types'

--- a/src/presets/classic/components/Socket.tsx
+++ b/src/presets/classic/components/Socket.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { ClassicPreset } from 'rete'
 import styled from 'styled-components'
 

--- a/src/presets/classic/components/refs/RefControl.tsx
+++ b/src/presets/classic/components/refs/RefControl.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { ClassicPreset } from 'rete'
 
 import { RefComponent } from '../../../../ref-component'

--- a/src/presets/classic/components/refs/RefSocket.tsx
+++ b/src/presets/classic/components/refs/RefSocket.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { ClassicPreset, NodeId } from 'rete'
 
 import { RefComponent } from '../../../../ref-component'

--- a/src/presets/classic/index.tsx
+++ b/src/presets/classic/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { ClassicPreset, Scope } from 'rete'
 import {
   classicConnectionPath, getDOMSocketPosition,

--- a/src/presets/context-menu/components/Item.tsx
+++ b/src/presets/context-menu/components/Item.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import styled, { css } from 'styled-components'
 
 import { useDebounce } from '../hooks'

--- a/src/presets/context-menu/components/Menu.tsx
+++ b/src/presets/context-menu/components/Menu.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import { useDebounce } from '../hooks'

--- a/src/presets/context-menu/components/Search.tsx
+++ b/src/presets/context-menu/components/Search.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import { ComponentType } from '../types'

--- a/src/presets/context-menu/index.tsx
+++ b/src/presets/context-menu/index.tsx
@@ -1,5 +1,5 @@
 
-import * as React from 'react'
+import React from 'react'
 import { BaseSchemes } from 'rete'
 
 import { RenderPreset } from '../types'

--- a/src/presets/minimap/components/MiniNode.tsx
+++ b/src/presets/minimap/components/MiniNode.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import { px } from '../utils'

--- a/src/presets/minimap/components/MiniViewport.tsx
+++ b/src/presets/minimap/components/MiniViewport.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import { useDrag } from '../../../shared/drag'

--- a/src/presets/minimap/components/Minimap.tsx
+++ b/src/presets/minimap/components/Minimap.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { useCallback, useRef } from 'react'
 import styled from 'styled-components'
 import { useElementSize } from 'usehooks-ts'

--- a/src/presets/minimap/index.tsx
+++ b/src/presets/minimap/index.tsx
@@ -1,5 +1,5 @@
 
-import * as React from 'react'
+import React from 'react'
 import { BaseSchemes } from 'rete'
 
 import { RenderPreset } from '../types'

--- a/src/presets/reroute-pins/Pin.tsx
+++ b/src/presets/reroute-pins/Pin.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import styled, { } from 'styled-components'
 
 import { useDrag } from '../../shared/drag'

--- a/src/presets/reroute-pins/index.tsx
+++ b/src/presets/reroute-pins/index.tsx
@@ -1,5 +1,5 @@
 
-import * as React from 'react'
+import React from 'react'
 import { BaseSchemes } from 'rete'
 import { BaseAreaPlugin } from 'rete-area-plugin'
 

--- a/src/ref-component.tsx
+++ b/src/ref-component.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 type RefUpdate = (ref: HTMLElement) => void
 type BaseProps = { init: RefUpdate, unmount: RefUpdate } & Record<string, unknown>

--- a/src/shared/drag.tsx
+++ b/src/shared/drag.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 import { Position } from '../types'
 import { copyEvent, findReactRoot } from './utils'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
         "strict": true,
-        "jsx": "react"
+        "jsx": "react",
+        "esModuleInterop": true,
     },
     "include": ["src"]
 }


### PR DESCRIPTION
fix issue: #50 
/claim #50 
remove the uncessary imports
`import * as React from 'react';`

and resolve the build failed when import react as default 

`

> rete-react-plugin@2.0.4 build
> rete build -c rete.config.ts

src/index.tsx:1:8 - error TS1259: Module '"/workspaces/react-plugin/node_modules/@types/react/ts5.0/index"' can only be default-imported using the 'esModuleInterop' flag

1 import React from 'react'
         ~~~~~

  node_modules/@types/react/ts5.0/index.d.ts:31:1
    31 export = React;
       ~~~~~~~~~~~~~~~
    This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.


Found 1 error in src/index.tsx:1

Type generating failed
@Zer-0ne ➜ /workspaces/react-plugin (main) $ npm run build

> rete-react-plugin@2.0.4 build
> rete build -c rete.config.ts

src/index.tsx:1:10 - error TS2617: 'React' can only be imported by using 'import React = require("react")' or by turning on the 'esModuleInterop' flag and using a default import.

1 import { React } from 'react'
           ~~~~~


Found 1 error in src/index.tsx:1

Type generating failed
`