### PR TITLE
Feature/shadow dom style support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rete-react-plugin",
-  "version": "2.0.5",
+  "version": "2.1.5",
   "description": "",
   "scripts": {
     "build": "rete build -c rete.config.ts",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,10 +28,17 @@ type Requires<Schemes extends BaseSchemes> =
 /**
  * Plugin props
  */
-export type Props = {
+export interface BaseRendererProps {
   /** root factory for React.js 18+ */
   createRoot?: (container: Element | DocumentFragment) => any
 }
+export interface RendererPropsWithLocalStyles
+  extends Omit<BaseRendererProps, 'createRoot'>, Required<Pick<BaseRendererProps, 'createRoot'>>
+{
+  /** add styles to wrapper (needed for shadow dom encapsulation), requires React.js 18+ */
+  localStyles: boolean;
+}
+export type Props = BaseRendererProps | RendererPropsWithLocalStyles
 
 /**
  * React plugin. Renders nodes, connections and other elements using React.
@@ -46,7 +53,7 @@ export class ReactPlugin<Schemes extends BaseSchemes, T = Requires<Schemes>> ext
 
   constructor(props?: Props) {
     super('react-render')
-    this.renderer = getRenderer({ createRoot: props?.createRoot })
+    this.renderer = getRenderer({ ...props })
 
     this.addPipe(context => {
       if (!context || typeof context !== 'object' || !('type' in context)) return context


### PR DESCRIPTION
As a developer working on a project that leverages web components (specifically using Lit for component creation), I've recently integrated rete.js into our setup. While the library wonderfully fits our needs, I encountered a challenge with styling components when using the rete-react-render-plugin. The styles were appended to document.head by styled-components, leading to unstyled components within my shadow DOM.

After investigating, I found that styled-components allows specifying a target for appending styles. I managed to work around this issue by extending the ReactPlugin as shown below:

```typescript
export class ShadowDomPlugin<Schemes extends BaseSchemes, T = Requires<Schemes>> extends ReactPlugin<Schemes, T> {
    constructor(props: Props & { createRoot: (container: HTMLElement) => any }, styleRoot: HTMLElement) {
        super({
            ...props,
            createRoot: container => {
                const root = props.createRoot(container);
                const render: (typeof root)['render'] = (children: any) => root.render(
                    React.createElement(StyleSheetManager, { target: styleRoot }, children),
                );
    
                return { ...root, render };
            },
        });
    }
}
```
usage: `const render = new ShadowDomPlugin<Schemes, AreaExtra>({ createRoot }, reteRoot);`


This approach, however, may not be immediately obvious to other developers and requires extending the library. To streamline the development experience and potentially broaden the appeal of rete.js for projects using shadow DOM, I propose an additional Prop-Flag within the ReactPlugin to facilitate this adjustment directly.

Here's how developers could use the new flag:
```typescript
const render = new ReactPlugin<Schemes, AreaExtra>({ createRoot, localStyles: true });
```

This enhancement minimizes friction for developers integrating rete.js into web component environments and encourages broader adoption of this powerful library.

Regarding automated testing, the CONTRIBUTING.md emphasizes the importance of tests, but I found no existing test framework in the project to integrate my tests. Despite this, I've manually tested the changes in my project, confirming they work as intended by directing styles into the shadow DOM effectively. I acknowledge the value of automated testing and am open to suggestions or future collaboration to align with the project's testing standards. At least I cared about the linting in the renderer.

I'm eager to hear your thoughts on this proposal and welcome any feedback or suggestions for improvement.

