### PR TITLE
fix: set input control text color for dark color-scheme

### DIFF
--- a/src/presets/classic/components/Control.tsx
+++ b/src/presets/classic/components/Control.tsx
@@ -8,6 +8,7 @@ const Input = styled.input<{ styles?: (props: any) => any }>`
   width: 100%;
   border-radius: 30px;
   background-color: white;
+  color: black;
   padding: 2px 6px;
   border: 1px solid #999;
   font-size: 110%;


### PR DESCRIPTION
### Description

Set an explicit `color: black` on classic preset input controls so values stay readable when the host page uses a dark `color-scheme` (e.g. Vite templates with `prefers-color-scheme: dark`). Without this, browsers paint light text on the control's white background.

### Related Issues

<!-- If your pull request is related to any GitHub issue(s), mention them here. -->

### Checklist

<!-- Mark the items that apply to this pull request -->

- [x] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [x] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [ ] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).

### Additional Notes

Same fix applied across render plugins: react, vue, svelte, lit.

Made with [Cursor](https://cursor.com)