### PR TITLE
fix(renderer): flushSync createRoot mount for layout-ready DOM

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
+import { flushSync } from 'react-dom'
 
 // React 18+ root type
 interface Root {
@@ -58,7 +59,9 @@ export function getRenderer(props?: { createRoot?: CreateRoot }): Renderer {
           roots.set(wrapper, root)
         }
 
-        root.render(element)
+        flushSync(() => {
+          root.render(element)
+        })
         return wrapper.firstElementChild ?? wrapper
       },
       unmount: (container: HTMLElement) => {


### PR DESCRIPTION
## Summary
- Wrap React 18+ `createRoot().render()` in `flushSync` so node DOM sizes are available immediately after `addNode`.
- Fixes incorrect `AreaExtensions.zoomAt()` centering caused by async `createRoot` commits (without relying on `setTimeout`).
- Legacy React 16/17 `ReactDOM.render` path is unchanged.

## Test plan
- [x] `npm run build`
- [x] `npm run lint` (0 errors)
- [ ] Manual: react18 / react-vite19 default template — `zoomAt` correct without timeout
- [ ] Smoke: react16 / react17 unchanged
- [ ] Optional: large-graph init for sync-commit cost


Made with [Cursor](https://cursor.com)